### PR TITLE
docs: add Pillow, lz4 and mapbox_earcut to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,6 @@ A decent PC. The more cores and ram the better. The more cores, the more ram it 
 pip install PyFFI numpy scipy shapely Pillow lz4 mapbox_earcut pytest
 ```
 
-> These three are easy to miss because almost every import in the pipeline is
-> lazy — nothing fails at startup. Without **Pillow** the terrain-LOD stage
-> writes zero tiles, without **lz4** every armor/clothing mesh fails once the
-> vanilla-asset cache is cold, and without **mapbox_earcut** individual cells
-> get no navmesh. In all three cases the run still ends with
-> "Pipeline complete".
-
 > **Navmesh native extensions.** The navmesh build requires two compiled modules,
 > committed prebuilt in `native/dist/` for **CPython 3.14 / 64-bit Windows**. A
 > `.pyd` only loads in a matching interpreter, so on any other Python version or

--- a/README.md
+++ b/README.md
@@ -53,14 +53,24 @@ A decent PC. The more cores and ram the better. The more cores, the more ram it 
 | **[numpy](https://numpy.org/)** | Skin retargeting math | `pip install numpy` |
 | **[scipy](https://scipy.org/)** | Navmesh triangulation, collision hulls, trees | `pip install scipy` |
 | **[shapely](https://shapely.readthedocs.io/)** | Navmesh corridor boolean union | `pip install shapely` |
+| **[Pillow](https://pypi.org/project/pillow/)** | Terrain-LOD texture compositing, object-LOD atlas normals, book inventory art. **Terrain LOD produces no tiles at all without it** | `pip install Pillow` |
+| **[lz4](https://pypi.org/project/lz4/)** | Reading Skyrim SE BSAs (v105) — how vanilla assets are fetched when `export/skyrim_assets/` has no cached copy yet | `pip install lz4` |
+| **[mapbox_earcut](https://pypi.org/project/mapbox-earcut/)** | Navmesh triangulation fallback when Delaunay fails on a piece | `pip install mapbox_earcut` |
 | **[pytest](https://pytest.org/)** | Test runner | `pip install pytest` |
 | **ffmpeg** | Voice/sound audio conversion | On `PATH` |
 | **xWMAEncode.exe** | xWMA voice compression | See note below |
 | **LipGenerator.exe** | Lip sync generation | Install the Creation Kit |
 
 ```bash
-pip install PyFFI numpy scipy shapely pytest
+pip install PyFFI numpy scipy shapely Pillow lz4 mapbox_earcut pytest
 ```
+
+> These three are easy to miss because almost every import in the pipeline is
+> lazy — nothing fails at startup. Without **Pillow** the terrain-LOD stage
+> writes zero tiles, without **lz4** every armor/clothing mesh fails once the
+> vanilla-asset cache is cold, and without **mapbox_earcut** individual cells
+> get no navmesh. In all three cases the run still ends with
+> "Pipeline complete".
 
 > **Navmesh native extensions.** The navmesh build requires two compiled modules,
 > committed prebuilt in `native/dist/` for **CPython 3.14 / 64-bit Windows**. A


### PR DESCRIPTION
﻿Hit all three of these on a fresh machine while converting Nehrim.esm. They're imported lazily, so nothing fails at startup — the stage just quietly does less and the run still ends with "Pipeline complete", which makes them hard to spot:

- **Pillow** — terrain LOD produced zero `.btr` tiles
- **lz4** — every armor/clothing mesh failed. Only bites when `export/skyrim_assets/` is still cold, which is probably why it never showed up for you
- **mapbox_earcut** — 8 cells got no navmesh

Docs only, no code changes.
