### PR TITLE
fix(lod): contain a LODGen crash instead of losing the whole worldspace

### DIFF
--- a/asset_convert/lod_gen.py
+++ b/asset_convert/lod_gen.py
@@ -695,15 +695,77 @@ def write_lodgen_input(esm_path: Path, output_dir: Path,
     return out_txt
 
 
+# LODGen 3.0.36.0, shipped alongside the 2.2.0.0 generator. It is NOT used to
+# bake — its output differs — but where 2.2 dies with an unhandled exception on
+# a worker thread and says nothing, 3.x catches the same fault per object and
+# prints `Error processing <EditorID>`. That name is the only way to learn
+# WHICH model is poisoning the run, so it is used purely as a detector.
+LODGEN_DETECT_EXE = (
+    SCRIPT_DIR / "external" / "lodgen" / "LODGenx64_new.exe"
+)
+
+_LODGEN_ERR_RE = _re.compile(r'Error processing (\S+)')
+
+# A single bad model aborts the whole worldspace, so a couple of rounds of
+# exclude-and-retry are worth it; beyond that something systemic is wrong and
+# looping only wastes minutes.
+_LODGEN_MAX_RETRIES = 4
+
+
+def _detect_lodgen_offenders(lodgen_input: Path) -> set:
+    """EditorIDs whose model faults LODGen, named by the 3.x detector."""
+    if not LODGEN_DETECT_EXE.exists():
+        return set()
+    try:
+        r = subprocess.run(
+            [str(LODGEN_DETECT_EXE), str(lodgen_input),
+             "--dontFixTangents", "--removeUnseenFaces"],
+            cwd=str(LODGEN_DETECT_EXE.parent),
+            capture_output=True, text=True, **POPEN_FLAGS)
+    except Exception as exc:
+        print(f"  (detector unavailable: {exc})")
+        return set()
+    return set(_LODGEN_ERR_RE.findall((r.stdout or "") + (r.stderr or "")))
+
+
+def _drop_refs(lodgen_input: Path, edids: set) -> int:
+    """Remove every reference line whose base EditorID is in *edids*."""
+    lines = lodgen_input.read_text(encoding='utf-8',
+                                   errors='replace').splitlines(True)
+    keep, dropped = [], 0
+    for line in lines:
+        fields = line.split('\t')
+        if len(fields) > 10 and fields[9] in edids:
+            dropped += 1
+            continue
+        keep.append(line)
+    if dropped:
+        lodgen_input.write_text(''.join(keep), encoding='utf-8')
+    return dropped
+
+
 def run_lodgen(lodgen_input: Path, output_dir: Path) -> bool:
-    """Invoke LODGenx64.exe on the prepared input file."""
+    """Invoke LODGenx64.exe, excluding models that crash it and retrying.
+
+    LODGen 2.2.0.0 handles no exceptions: one model it cannot process throws
+    on a ThreadPool worker and kills the process, so every remaining tile of
+    the worldspace is silently lost. Measured on Nehrim: 28 of 418 object-LOD
+    tiles were baked, twice in a row, because of ONE model
+    (`LeyawiinHouseLower01`). Excluding just that model's 5 references let all
+    418 tiles bake. The mesh itself parses fine and its geometry is valid —
+    both a tangent-flag repair and a recomputed-normals repair were tried and
+    made it crash EARLIER, so the fault is inside LODGen, not in the file.
+
+    So: run it, and if it dies, ask the 3.x detector which model it choked on,
+    drop that model's references and try again. An excluded model has no
+    distant-LOD copy — it pops in at load distance — which is a far smaller
+    loss than the entire worldspace having no object LOD.
+    """
     if not LODGEN_EXE.exists():
         print(f"  ERROR: LODGenx64.exe not found at {LODGEN_EXE}")
         return False
 
-    # Ensure output terrain/Objects dir exists (LODGen may not create it)
     # PathOutput is embedded in the input file; LODGen reads it from there.
-
     cmd = [
         str(LODGEN_EXE),
         str(lodgen_input),
@@ -712,19 +774,39 @@ def run_lodgen(lodgen_input: Path, output_dir: Path) -> bool:
         # --skyblivionTexPath is NOT used: it prepends an extra 'tes4\\' to texture paths
         # already under textures\\tes4\\, doubling the prefix and causing null-ptr crashes.
     ]
-    print(f"  Running: {' '.join(cmd)}")
-    # Capture output so it reaches the GUI log instead of a popped-up console
-    # window (which never exists under the console-less GUI launcher).
-    result = subprocess.run(cmd, cwd=str(LODGEN_EXE.parent),
-                            capture_output=True, text=True, **POPEN_FLAGS)
-    if result.stdout:
-        print(result.stdout, end="")
-    if result.stderr:
-        print(result.stderr, end="")
-    if result.returncode != 0:
+    excluded: set = set()
+    for attempt in range(_LODGEN_MAX_RETRIES + 1):
+        print(f"  Running: {' '.join(cmd)}")
+        # Capture output so it reaches the GUI log instead of a popped-up console
+        # window (which never exists under the console-less GUI launcher).
+        result = subprocess.run(cmd, cwd=str(LODGEN_EXE.parent),
+                                capture_output=True, text=True, **POPEN_FLAGS)
+        if result.stdout:
+            print(result.stdout, end="")
+        if result.stderr:
+            print(result.stderr, end="")
+        if result.returncode == 0:
+            if excluded:
+                print(f"  Object LOD baked with {len(excluded)} model(s) "
+                      f"excluded: {', '.join(sorted(excluded))}")
+            return True
+
         print(f"  WARNING: LODGenx64.exe exited with code {result.returncode}")
-        return False
-    return True
+        if attempt >= _LODGEN_MAX_RETRIES:
+            break
+        offenders = _detect_lodgen_offenders(lodgen_input) - excluded
+        if not offenders:
+            print("  Could not identify the offending model; giving up "
+                  "(object LOD will be incomplete)")
+            break
+        dropped = _drop_refs(lodgen_input, offenders)
+        if not dropped:
+            break
+        excluded |= offenders
+        print(f"  Excluding {len(offenders)} crashing model(s) "
+              f"({dropped} references) and retrying: "
+              f"{', '.join(sorted(offenders))}")
+    return False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
﻿On my Nehrim run, object LOD came out at **28 of 418 tiles** — twice in a row, identically.

Cause is that LODGenx64 2.2.0.0 has no exception handling. One model it can't process throws `ArgumentOutOfRangeException` on a ThreadPool worker, the process dies, and every tile that hadn't been written yet is lost. For me it was `LeyawiinHouseLower01`, which has 5 references in the entire game. Dropping just those 5 lines from the LODGen input gave me all 418 tiles.

So `run_lodgen` now retries: run it, and if it dies, ask **`LODGenx64_new.exe` (3.0.36.0) — which is already in the repo but unused** — for the name. 3.x catches the same fault per object and prints `Error processing <EditorID>`, which as far as I can tell is the only way to find out which model is responsible. Those references get dropped and the bake is retried, max 4 rounds. It reports what it excluded at the end.

An excluded model has no distant-LOD copy and pops in at load distance, which is a much smaller loss than the whole worldspace having no object LOD at all.

**Negative results, so nobody repeats them:** the mesh is fine. I tried repairing the tangent flag (`extra_vectors_flags` claiming tangents the format never writes for a normal-less shape) and recomputing the missing normals. Both made it crash *earlier*, at 0 tiles. The fault is inside LODGen, not in the file.

Verified end-to-end against my real 150,267-reference input, before your latest push — `lod_gen.py` is untouched by it, so the code is identical to what I tested.
