### PR TITLE
fix: write the slot-44 patch to output/ instead of output/Oblivion.esm/

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -807,7 +807,14 @@ def phase_modify_body_meshes(tes5_data: str = None, plugins: list = None,
 
     plugins = plugins or ["Skyrim.esm"]
     out_root = Path(output_dir) if output_dir else SCRIPT_DIR / "output"
-    out_path = out_root / "Oblivion.esm" / "Slot44 Patch.esp"
+    # Straight into output/, NOT into a per-plugin folder. This step takes no
+    # `-f` and patches the vanilla Skyrim body records for the whole load
+    # order, so it belongs to no single conversion. Hardcoding "Oblivion.esm"
+    # put it somewhere `--pack-only -f <other plugin>` never looks: converting
+    # Nehrim created an otherwise-empty output/Oblivion.esm/ holding just this
+    # file, and it shipped with nothing.
+    out_root.mkdir(parents=True, exist_ok=True)
+    out_path = out_root / "Slot44 Patch.esp"
 
     plugin_paths = []
     for name in plugins:


### PR DESCRIPTION
﻿`phase_modify_body_meshes` takes no `-f` and patches the vanilla Skyrim body records for the whole load order, so it doesn't belong to any single conversion — but the output folder was hardcoded:

```python
out_path = out_root / "Oblivion.esm" / "Slot44 Patch.esp"
```

Converting Nehrim therefore created an otherwise-empty `output/Oblivion.esm/` containing just this one file, where `--pack-only -f Nehrim.esm` never looks. The patch was neither packed nor shipped, so slot 44 was referenced with nothing providing it.

Now writes to `output/Slot44 Patch.esp`. Verified with `python convert.py --modify-body-meshes`:

```
Written: ...\output\Slot44 Patch.esp  (1051 records, ESL-flagged masters: ['Skyrim.esm'])
```

**Related but deliberately not in this PR**, since you've already said the docs are wrong there and the mesh side is broken: `asset_convert/modify_body_meshes.py` defaults its `--output-dir` to `output/oblivion.esm/meshes/...` the same way, and `phase_modify_body_meshes` never calls that script at all despite its docstring saying it does both.
