### PR TITLE
fix(textures): merge the texture manifest on a --mesh-subdirs run

### DIFF
--- a/asset_convert/asset_pipeline.py
+++ b/asset_convert/asset_pipeline.py
@@ -94,8 +94,14 @@ def convert_meshes(source_file, extract_dir='export', output_dir='output',
         # The textures the converted meshes reference, harvested as they were
         # written.  Persisted because the prune runs in a later phase (after LOD
         # and speedtrees add their own meshes), possibly a separate invocation.
-        texture_prune.write_manifest(
-            plugin_dir, stats['mesh_conversion'].pop('textures_used', set()))
+        #
+        # A --mesh-subdirs run only saw part of the tree, so it must ADD to the
+        # manifest rather than replace it: overwriting leaves the prune believing
+        # nothing outside those folders uses a texture, and it deletes the rest.
+        _used = stats['mesh_conversion'].pop('textures_used', set())
+        if mesh_subdirs:
+            _used = set(_used) | texture_prune.read_manifest(plugin_dir)
+        texture_prune.write_manifest(plugin_dir, _used)
     else:
         print(f"  No meshes found at {mesh_src}")
         stats['mesh_conversion'] = {'converted': 0, 'skipped': 0, 'errors': 0}


### PR DESCRIPTION
Independent of my other open PRs — one file, based on current master.

The mesh stage records every texture the converted meshes reference, so the later prune knows what is still in use. A `--mesh-subdirs` run only walks part of the tree, but it **overwrote** the manifest with just what it saw.

The prune then believes nothing outside those folders uses a texture and deletes the rest. So a scoped mesh rebuild — the entire point of the flag — arms a delayed data loss that only fires on the next `--prune-textures-only`, by which time the cause is long out of sight.

Merge into the existing manifest when the run was scoped. A full run still replaces it, so a texture that genuinely fell out of use is still pruned.

Found while scoping a mesh rebuild to ten folders for #25 — I was about to hand someone a command with that landmine in it.
