### PR TITLE
Update TODO.txt

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -101,3 +101,5 @@ Minor Issues:
 
 	17 - Pandora compatibility
 
+	18 - should not be able to teleport to places you haven't yet visited (all map markers are visible upon entering worldspace)
+


### PR DESCRIPTION
Upon teleporting to the Oblivion worldspace, all map markers for major cities are automatically unlocked. I've been unable to test without teleporting to the worldspace, but presuming this is an issue regardless of the method a new game/player arrives in Cyrodil, it should be fixed.

Another issue I've noted is that monsters don't appear to attack the player, and the textures on many of them are wrong (Mudcrabs) I also noticed slaughterfish on dry land, no enemies attack me, and there are some visual bugs (if you do the teleport command, the area it sends you to has a few apparent issues with grass and water not being where they should, presuming that's why slaughterfish were swimming around on what looked to be dry land...)