### PR TITLE
fix(textures): strip a leading 'data\' from mesh texture paths

### DIFF
--- a/asset_convert/nif_converter.py
+++ b/asset_convert/nif_converter.py
@@ -615,8 +615,18 @@ def _rewrite_tex_path(raw_bytes):
     prefix, documented "used mainly for making _far.nifs"). We do not ship a
     lowres tree — the converted textures live at the normal path — so the
     segment is dropped and the reference resolves to the real texture.
+
+    A leading 'data\\' is an authoring slip Oblivion tolerates (it resolves
+    paths from the Data folder either way) and Skyrim does not. Measured across
+    Nehrim's 12,437 source meshes: 4 distinct textures in 10 meshes, among them
+    dwarven\\rock02.dds in 7. Left in, the reference came out as
+    'Textures\\tes4\\data\\textures\\...' — nothing there, AND the prune then
+    deleted the real texture, because the manifest key never matched the
+    shipped path.
     """
     path = raw_bytes.decode('utf-8', errors='replace').replace('/', '\\')
+    if path.lower().startswith('data\\'):
+        path = path[len('data\\'):]
     low = path.lower()
 
     if low.startswith('textures\\'):

--- a/tests/test_asset_convert.py
+++ b/tests/test_asset_convert.py
@@ -50,6 +50,21 @@ class TestTexturePathRewriting:
         result = _rewrite_tex_path(b'Textures\\Armor\\Iron\\Cuirass.dds')
         assert 'tes4' in result.lower()
 
+    def test_data_prefix_is_stripped(self):
+        """An authoring slip Oblivion tolerates and Skyrim does not.
+
+        Measured in Nehrim's source meshes: 4 distinct textures across 10
+        meshes, dwarven\\rock02.dds in 7 of them.  Left in, the reference came
+        out under a 'data' folder that does not exist, AND the prune deleted
+        the real texture because the key never matched the shipped path.
+        """
+        result = _rewrite_tex_path(b'data\\textures\\dwarven\\rock02.dds')
+        assert result == 'Textures\\tes4\\dwarven\\rock02.dds'
+
+    def test_data_prefix_with_forward_slashes(self):
+        result = _rewrite_tex_path(b'Data/Textures/dwarven/rock01.dds')
+        assert result == 'Textures\\tes4\\dwarven\\rock01.dds'
+
 
 class TestBoneMapping:
     """Test bone name remapping."""


### PR DESCRIPTION
Some Oblivion meshes name their textures with a leading `data\` — `data\textures\dwarven\rock02.dds` rather than `textures\dwarven\rock02.dds`. Oblivion tolerates it, because it resolves texture paths relative to the Data folder either way. Skyrim does not.

`_rewrite_tex_path` passed the prefix straight through, so the converted mesh came out referencing `Textures\tes4\data\textures\dwarven\rock02.dds` — a path with a `data` folder in the middle that nothing ever writes.

## It costs two textures, not one

The dead reference is the obvious half. The second half is worse and is why this is a fix rather than a tidy-up: the texture prune keys on the paths the meshes actually name, so `dwarven\rock02.dds` never appeared in the manifest and **the real texture was deleted from the output** as unreferenced. The mesh loses its texture whether or not the bad path is corrected at load time.

## Scale

Measured across Nehrim's 12,437 source meshes: **4 distinct textures in 10 meshes**, `dwarven\rock02.dds` in 7 of them. Small, but silent — a missing diffuse on a handful of dwarven meshes is not something anyone traces back to a path prefix.

## The fix

One line, before the existing prefix handling, so the `textures\` and `lowres\` logic below sees a normal path:

```python
if path.lower().startswith('data\\'):
    path = path[len('data\\'):]
```

It sits after the `/` → `\` normalisation that was already there, so `Data/Textures/...` is caught too — both spellings occur.

Two tests in `TestTexturePathRewriting`, one per spelling. The existing cases in that class are unchanged and still pass, which is the point: this only ever removes a prefix that should not have been in the file.
