### PR TITLE
fix(lod): stop the mesh-safety warm-up caching a verdict for an unstaged mesh

### DIFF
--- a/asset_convert/lod_gen.py
+++ b/asset_convert/lod_gen.py
@@ -625,6 +625,21 @@ def _lod_mesh_is_safe(path: str, output_meshes_dir: Path) -> bool:
     if cached is not None:
         return cached
 
+    if not full.exists():
+        # 🔴 NOT cached, and that is the whole point.  Absence is TRANSIENT
+        # here: the caller stages a mesh into this tree
+        # (`_import_master_mesh`) and screens it immediately afterwards, so a
+        # verdict taken before staging would be served from the cache after it
+        # and drop a mesh that is now sitting there perfectly readable.
+        #
+        # This is what broke object LOD for every worldspace once `output_dir`
+        # became the shared LOD mod rather than the plugin's own output: at
+        # prefetch time that tree is EMPTY, so every mesh cached as unsafe and
+        # each worldspace ended with "No LOD references found".  It was
+        # invisible before, because the plugin's own meshes were already in
+        # `output_dir` and only master-owned ones were ever staged.
+        return False
+
     safe = _root_is_ninode(full)
     _NIF_ROOT_SAFE_CACHE[key] = safe
     return safe
@@ -675,7 +690,8 @@ def _screenable_mesh_paths(refs, stats, cell_wrld, wrld_fid, keep_cells):
     return out
 
 
-def _prescreen_meshes(paths, output_meshes_dir: Path, workers: int = 16):
+def _prescreen_meshes(paths, output_meshes_dir: Path, workers: int = 16,
+                      source_meshes=None):
     """Warm `_NIF_ROOT_SAFE_CACHE` for `paths` using parallel header reads.
 
     Screening is a ~200-byte header read per unique mesh, so the cost is
@@ -691,6 +707,20 @@ def _prescreen_meshes(paths, output_meshes_dir: Path, workers: int = 16):
     Purely a warm-up — every entry is computed by the same `_root_is_ninode`
     the serial path uses, and any mesh missed here is simply screened on demand
     later. Order-independent, so it cannot affect FormIDs or output bytes.
+
+    🔴 A mesh that exists in NEITHER tree is skipped rather than cached as
+    unsafe.  The serial loop stages master-owned meshes into
+    `output_meshes_dir` and screens them right after, so caching "missing =
+    unsafe" up front would answer the later question with a stale verdict.
+    That is exactly what cost every worldspace its object LOD once
+    `output_dir` became the shared LOD mod (see `_lod_mesh_is_safe`).
+
+    `source_meshes` is where the serial loop stages FROM. Screening the source
+    is equivalent to screening the staged copy — `_import_master_mesh` uses
+    `shutil.copy2`, so the two are byte-identical — and it is what keeps the
+    warm-up worth doing at all in the shared-LOD-mod case, where nothing is in
+    `output_meshes_dir` yet. Resolution mirrors `_import_master_mesh`: this
+    tree first, then the source dirs in order, first hit wins.
     """
     todo = []
     seen = set()
@@ -702,7 +732,20 @@ def _prescreen_meshes(paths, output_meshes_dir: Path, workers: int = 16):
         if key in _NIF_ROOT_SAFE_CACHE or key in seen:
             continue
         seen.add(key)
-        todo.append((key, full))
+        read_from = full
+        if not full.exists():
+            rel = p.lower().replace('/', '\\').lstrip('\\')
+            if rel.startswith('meshes\\'):
+                rel = rel[len('meshes\\'):]
+            read_from = None
+            for mdir in (source_meshes or []):
+                cand = _win_join(Path(mdir), rel)
+                if cand.exists():
+                    read_from = cand
+                    break
+            if read_from is None:
+                continue          # nowhere yet — let the serial path decide
+        todo.append((key, read_from))
     if len(todo) < 2:
         return
     from concurrent.futures import ThreadPoolExecutor
@@ -1174,9 +1217,14 @@ def write_lodgen_input(esm_path: Path, output_dir: Path,
     # with the same helpers the loop uses); anything else still resolves
     # on demand, so this can only remove work, never change which meshes are
     # judged safe.
+    #
+    # `master_meshes` has to come along: the loop STAGES from there into this
+    # tree and screens right afterwards, so a warm-up that only looked here
+    # would cache "missing" for every mesh not yet staged — which is precisely
+    # how the shared LOD mod lost object LOD in all 18 worldspaces.
     _prescreen_meshes(_screenable_mesh_paths(refs, stats, cell_wrld, wrld_fid,
                                              keep_cells),
-                      output_meshes_dir)
+                      output_meshes_dir, source_meshes=master_meshes)
 
     for ref in refs:
         # Must be in our worldspace

--- a/asset_convert/nif_converter.py
+++ b/asset_convert/nif_converter.py
@@ -3672,7 +3672,9 @@ def _add_bsx_flags(root, has_constraints=False):
 
 
 def _sanitize_geometry_data(data):
-    """Zero out non-finite floats in render geometry.
+    """Repair geometry Oblivion tolerates and the Skyrim-side tools do not.
+
+    Two defects, both authored, both fatal further down the line.
 
     A handful of Oblivion source meshes ship NaN data (anvildooruc02.nif has
     9 NaN UVs, middlecandlestickfloor03fake.nif has 2 — one mesh in each of
@@ -3685,11 +3687,61 @@ def _sanitize_geometry_data(data):
     non-finite normals/tangents/bitangents become +Z; a non-finite bound
     sphere is recomputed after vertices are fixed.
 
+    The second is a shape that declares vertices and ships none — see the
+    comment on that branch. It is cleared to a genuinely empty shape, because
+    without positions there is nothing to repair it with.
+
     Returns the number of components fixed.
     """
     fixed = 0
     for block in data.blocks:
         if not isinstance(block, NifFormat.NiGeometryData):
+            continue
+
+        # A shape that declares vertices and then ships NONE of them.
+        # `LeyawiinLowerDoor01` in leyawiinhouselower01.nif is the measured
+        # case: num_vertices=16, has_vertices=False, yet normals, colours, UVs
+        # and 6 triangles all still index 16 of them. Oblivion tolerates it
+        # (there is nothing to draw, so it draws nothing); anything that walks
+        # the faces and reaches for a vertex does not.
+        #
+        # LODGen is what found it: RemoveUnseenFaces indexes straight into the
+        # empty list, throws ArgumentOutOfRangeException, and the run ends with
+        # exit 548 and NO .bto tiles — one broken shape costs an entire
+        # worldspace its object LOD. Measured: 1 of Nehrim's 1552 _far.nif.
+        #
+        # Cleared rather than repaired, because there is nothing to repair
+        # with: without vertex positions the triangles have no geometry to
+        # describe. The shape already drew nothing, so it loses nothing.
+        if block.num_vertices and not getattr(block, 'has_vertices', False):
+            block.num_vertices = 0
+            block.vertices.update_size()
+            for flag, arr in (('has_normals', 'normals'),
+                              ('has_vertex_colors', 'vertex_colors')):
+                if getattr(block, flag, False):
+                    setattr(block, flag, False)
+                    getattr(block, arr).update_size()
+            if hasattr(block, 'uv_sets'):
+                block.num_uv_sets = 0
+                block.uv_sets.update_size()
+            block.num_triangles = 0
+            # 🔴 BOTH geometry layouts, and the strips are the one that bites.
+            # The measured case is `NiTriStripsData`, which has no `triangles`
+            # array at all — it stores STRIPS. A first version of this cleared
+            # only `triangles`, so the strips survived, the strips-to-triangles
+            # conversion downstream turned them back into 6 triangles, and the
+            # shape shipped with zero vertices and six faces indexing vertex 15.
+            # LODGen happened to tolerate that; the next tool would not.
+            if hasattr(block, 'triangles'):
+                block.num_triangle_points = 0
+                block.has_triangles = False
+                block.triangles.update_size()
+            if hasattr(block, 'points'):
+                block.num_strips = 0
+                block.has_points = False
+                block.strip_lengths.update_size()
+                block.points.update_size()
+            fixed += 1
             continue
 
         if getattr(block, 'has_vertices', False) and block.num_vertices:

--- a/tests/test_geometry_sanitize.py
+++ b/tests/test_geometry_sanitize.py
@@ -1,0 +1,158 @@
+"""A shape that declares vertices and ships none must not reach the output.
+
+`LeyawiinLowerDoor01` in `leyawiinhouselower01.nif` is the measured case:
+`num_vertices = 16` with `has_vertices = False`, while normals, colours, UVs
+and 6 triangles all still index 16 vertices that are not in the file.
+
+Oblivion tolerates it — there is nothing to draw, so it draws nothing. LODGen
+does not: `RemoveUnseenFaces` indexes straight into the empty list, throws
+`ArgumentOutOfRangeException`, and the whole run ends with exit 548 and NO
+`.bto` tiles. One shape like this cost NehrimWorldspace every bit of its
+object LOD while the other 17 worldspaces baked fine.
+
+Measured scope: 1 of Nehrim's 1552 shipped `_far.nif`.
+"""
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+@pytest.fixture
+def nif():
+    if not hasattr(time, 'clock'):
+        time.clock = time.perf_counter
+    from asset_convert import pyffi_monkey_patch            # noqa: F401
+    from pyffi.formats.nif import NifFormat
+    return NifFormat
+
+
+def _shape_with_no_vertex_array(NifFormat):
+    """Rebuild the authored defect exactly as it comes off disk.
+
+    Read back from the real file, `LeyawiinLowerDoor01` is
+    ``num_vertices=16, has_vertices=False, len(vertices)=0`` with 6 triangles
+    whose highest index is 15. `update_size()` alone will not produce that —
+    it sizes the array from `num_vertices` regardless of the flag — so the
+    list is sized while the count is still 0 and the count set afterwards.
+    """
+    shape = NifFormat.NiTriShape()
+    data = NifFormat.NiTriShapeData()
+    shape.data = data
+
+    data.has_vertices = False              # <- the defect
+    data.num_vertices = 0
+    data.vertices.update_size()            # -> genuinely empty, as on read
+    data.num_vertices = 16
+
+    data.has_normals = True
+    data.normals.update_size()
+    data.has_vertex_colors = True
+    data.vertex_colors.update_size()
+    data.num_uv_sets = 1
+    data.uv_sets.update_size()
+
+    tris = [(0, 1, 2), (3, 4, 5), (6, 7, 8),
+            (9, 10, 11), (12, 13, 14), (13, 14, 15)]
+    data.num_triangles = len(tris)
+    data.num_triangle_points = len(tris) * 3
+    data.triangles.update_size()
+    for t, (a, b, c) in zip(data.triangles, tris):
+        t.v_1, t.v_2, t.v_3 = a, b, c
+    return shape, data
+
+
+class TestVertexlessShapeIsCleared:
+
+    def test_the_fixture_reproduces_the_authored_defect(self, nif):
+        """Guard on the guard: if this stops being reproducible the test
+        below proves nothing."""
+        _shape, data = _shape_with_no_vertex_array(nif)
+        # Exactly what the real file reads back as.
+        assert data.num_vertices == 16
+        assert not data.has_vertices
+        assert len(data.vertices) == 0, 'fixture is not vertex-less'
+        assert len(data.get_triangles()) == 6
+        assert max(max(t) for t in data.get_triangles()) == 15, \
+            'triangles must index vertices that are not there'
+
+    def test_it_is_cleared_to_an_empty_shape(self, nif):
+        from asset_convert.nif_converter import _sanitize_geometry_data
+
+        shape, data = _shape_with_no_vertex_array(nif)
+
+        class _Doc:
+            blocks = [data]
+
+        assert _sanitize_geometry_data(_Doc()) >= 1
+        assert data.num_vertices == 0
+        assert len(data.get_triangles()) == 0, \
+            'triangles left pointing at vertices that do not exist'
+        assert not data.has_normals
+        assert not data.has_vertex_colors
+
+    def test_the_strips_layout_is_cleared_too(self, nif):
+        """The measured case is STRIPS, not triangles.
+
+        `LeyawiinLowerDoor01` is a `NiTriStrips`: its data block has no
+        `triangles` array at all. Clearing only `triangles` left the strips
+        untouched, the strips-to-triangles conversion downstream rebuilt them,
+        and the shape shipped with 0 vertices and 6 faces indexing vertex 15.
+        """
+        from asset_convert.nif_converter import _sanitize_geometry_data
+
+        data = nif.NiTriStripsData()
+        data.has_vertices = False
+        data.num_vertices = 0
+        data.vertices.update_size()
+        data.num_vertices = 16
+        assert not hasattr(data, 'triangles'), \
+            'fixture must exercise the strips layout, not triangles'
+
+        data.num_strips = 1
+        data.strip_lengths.update_size()
+        data.strip_lengths[0] = 8
+        data.has_points = True
+        data.points.update_size()
+        for i in range(8):
+            data.points[0][i] = i + 8
+        data.num_triangles = len(data.get_triangles())
+        assert data.num_triangles > 0, 'fixture has no geometry to clear'
+
+        class _Doc:
+            blocks = [data]
+
+        assert _sanitize_geometry_data(_Doc()) >= 1
+        assert data.num_vertices == 0
+        assert len(data.get_triangles()) == 0, 'strips survived the clear'
+        assert data.num_strips == 0
+
+    def test_a_healthy_shape_is_untouched(self, nif):
+        """The sanitiser must not reach a normal mesh — it runs on every
+        converted NIF."""
+        from asset_convert.nif_converter import _sanitize_geometry_data
+
+        shape = nif.NiTriShape()
+        data = nif.NiTriShapeData()
+        shape.data = data
+        data.num_vertices = 3
+        data.has_vertices = True
+        data.vertices.update_size()
+        for i, v in enumerate(data.vertices):
+            v.x, v.y, v.z = float(i), 0.0, 0.0
+        data.num_triangles = 1
+        data.num_triangle_points = 3
+        data.triangles.update_size()
+        data.triangles[0].v_1 = 0
+        data.triangles[0].v_2 = 1
+        data.triangles[0].v_3 = 2
+
+        class _Doc:
+            blocks = [data]
+
+        assert _sanitize_geometry_data(_Doc()) == 0
+        assert data.num_vertices == 3
+        assert len(data.get_triangles()) == 1

--- a/tests/test_lod_mesh_screening.py
+++ b/tests/test_lod_mesh_screening.py
@@ -1,0 +1,137 @@
+"""The mesh-safety screen must never cache a verdict for a file that is
+not there yet.
+
+LODGen casts every listed LOD mesh's root block to NiNode without checking, and
+one bad mesh kills the WHOLE worldspace — so each mesh gets a header read first
+and the result is memoised.  The memo is warmed concurrently before the serial
+loop, because those reads are pure file-open latency.
+
+The trap is that the serial loop STAGES meshes into the tree it screens
+(`_import_master_mesh` copies a master-owned mesh in, because LODGen resolves
+everything under one PathData root) and screens them immediately afterwards.
+So a mesh's existence is not stable across the warm-up: caching "missing =
+unsafe" up front answers the later question with a stale verdict.
+
+That went unnoticed while `output_dir` was the plugin's own output — its meshes
+were already there and only master-owned ones were ever staged.  Once
+`e4b8d91` made `output_dir` the shared LOD mod, that tree is EMPTY at warm-up
+time, every mesh cached as unsafe, and all 18 worldspaces ended with
+"No LOD references found".
+"""
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from asset_convert import lod_gen                                  # noqa: E402
+
+
+@pytest.fixture
+def screen(monkeypatch):
+    """Isolate the cache and stub the header read.
+
+    What is under test is the RESOLUTION and CACHING, not the NIF header
+    parser, so the parser is replaced by "a file that exists is fine".  That
+    keeps the test from needing a hand-built NIF and makes a failure point at
+    the logic that actually changed.
+    """
+    monkeypatch.setattr(lod_gen, '_NIF_ROOT_SAFE_CACHE', {})
+    monkeypatch.setattr(lod_gen, '_root_is_ninode',
+                        lambda full: Path(full).exists())
+    return lod_gen
+
+
+REL = 'architecture\\lazeon\\wall01.nif'
+REL2 = 'architecture\\lazeon\\wall02.nif'
+
+
+def _tree(tmp_path):
+    """An empty shared LOD mod beside a plugin output that owns the meshes.
+
+    Two meshes, because `_prescreen_meshes` does not spin up a thread pool for
+    a single file — one would exercise the on-demand path instead of the
+    warm-up this is about.
+    """
+    out = tmp_path / 'AutoConvertLOD' / 'meshes'
+    src = tmp_path / 'Nehrim.esm' / 'meshes'
+    (src / 'architecture' / 'lazeon').mkdir(parents=True)
+    for rel in (REL, REL2):
+        (src / rel.replace('\\', '/')).write_bytes(b'NIF')
+    out.mkdir(parents=True)
+    return out, src
+
+
+def _stage(out, src):
+    dst = out / 'architecture' / 'lazeon' / 'wall01.nif'
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src / 'architecture' / 'lazeon' / 'wall01.nif', dst)
+
+
+class TestScreenDoesNotCacheAbsence:
+
+    def test_a_mesh_staged_after_the_warm_up_is_still_judged_safe(
+            self, screen, tmp_path):
+        """The regression, in the order it actually happens.
+
+        Warm-up runs against an empty tree, the loop stages the mesh, then
+        screens it. Before the fix the screen answered from a cached False and
+        the object was dropped — with its worldspace, once enough of them were.
+        """
+        out, src = _tree(tmp_path)
+        screen._prescreen_meshes([REL, REL2], out)          # no source dirs
+        _stage(out, src)
+        assert screen._lod_mesh_is_safe(REL, out) is True
+
+    def test_the_warm_up_reads_the_source_tree_when_this_one_is_empty(
+            self, screen, tmp_path):
+        """...and it must still be a warm-up, not a no-op.
+
+        `_import_master_mesh` stages with `shutil.copy2`, so the source and the
+        staged copy are byte-identical and screening either gives the same
+        answer. Reading the source is what keeps the concurrent prefetch worth
+        doing in the shared-LOD-mod case, where nothing is staged yet.
+        """
+        out, src = _tree(tmp_path)
+        screen._prescreen_meshes([REL, REL2], out, source_meshes=[src])
+        key = str(screen._mesh_screen_path(REL, out)).lower()
+        assert screen._NIF_ROOT_SAFE_CACHE.get(key) is True, \
+            'source not consulted — the prefetch degenerates to a no-op'
+
+    def test_a_mesh_in_no_tree_at_all_is_not_cached(self, screen, tmp_path):
+        out, src = _tree(tmp_path)
+        screen._prescreen_meshes([REL, REL2, 'nowhere\\b.nif'], out,
+                                 source_meshes=[src])
+        gone = str(screen._mesh_screen_path('nowhere\\b.nif', out)).lower()
+        assert gone not in screen._NIF_ROOT_SAFE_CACHE
+        # and it still reads as unsafe on demand, which is the safe answer
+        assert screen._lod_mesh_is_safe('nowhere\\b.nif', out) is False
+        assert gone not in screen._NIF_ROOT_SAFE_CACHE, \
+            'an absent mesh must never be memoised — it may be staged later'
+
+    def test_a_real_verdict_is_still_cached(self, screen, tmp_path):
+        """The memo has to keep working, or Tamriel's 2,582 header reads go
+        back to being serial file-open latency."""
+        out, src = _tree(tmp_path)
+        _stage(out, src)
+        assert screen._lod_mesh_is_safe(REL, out) is True
+        key = str(screen._mesh_screen_path(REL, out)).lower()
+        assert screen._NIF_ROOT_SAFE_CACHE[key] is True
+        # cached, so a later deletion cannot change the answer within one bake
+        (out / 'architecture' / 'lazeon' / 'wall01.nif').unlink()
+        assert screen._lod_mesh_is_safe(REL, out) is True
+
+    def test_an_unsafe_mesh_is_still_rejected(self, screen, tmp_path,
+                                              monkeypatch):
+        """The screen's actual job: a root LODGen cannot cast is excluded.
+
+        The fix must not turn the screen into a mere existence check — a mesh
+        that IS there and has a geometry root still has to be dropped, or one
+        of them aborts the bake and the worldspace loses all its object LOD.
+        """
+        out, src = _tree(tmp_path)
+        _stage(out, src)
+        monkeypatch.setattr(screen, '_root_is_ninode', lambda full: False)
+        assert screen._lod_mesh_is_safe(REL, out) is False


### PR DESCRIPTION
Object LOD was failing for **every worldspace** on Nehrim — all 18 ended with `No LOD references found`, right after discarding thousands of meshes as unreadable (2,368 for NehrimWorldspace alone). Terrain LOD was fine; only `Objects/` was empty.

The meshes are not the problem: checked afterwards, `_root_is_ninode` and `_root_is_ninode_slow` both return `True` for them, and the header fast path agrees with the full parse on 250 of 250.

## Cause: the warm-up caches a verdict that is not yet stable

`_prescreen_meshes` warms `_NIF_ROOT_SAFE_CACHE` concurrently before the serial loop, which is a good optimisation — those reads are pure file-open latency. But the serial loop **stages meshes into the very tree it screens**: `_import_master_mesh` copies a master-owned mesh in, because LODGen resolves everything under one PathData root, and screens it immediately afterwards.

So a mesh's existence is not stable across the warm-up:

1. warm-up runs, the file is not in `output_meshes_dir` yet → `_root_is_ninode` returns `False` → **cached**
2. the loop stages the mesh — now present and perfectly readable
3. `_lod_mesh_is_safe` is answered from the cache and drops the object

`_prescreen_meshes` says in its own docstring that it "can only remove work, never change which meshes are judged safe". That holds only while the file state does not change underneath it.

**This was invisible until `e4b8d91`.** While `output_dir` was the plugin's own output, its meshes were already there at warm-up time and only master-owned ones were ever staged — the ElsweyrAnequina case, a minority. Once `output_dir` became the shared LOD mod, that tree is *empty* at warm-up time, so essentially every mesh cached as unsafe.

Nothing about the centralisation is changed here; it is the right call and it stays.

### Fix

- `_lod_mesh_is_safe` no longer caches a verdict for a file that does not exist. It still answers "unsafe", which is the safe answer for a genuinely missing mesh — it just does not remember it.
- `_prescreen_meshes` takes the dirs the loop stages **from** and reads the source when this tree is empty. `_import_master_mesh` copies with `shutil.copy2`, so source and staged copy are byte-identical and screening either gives the same answer. Without this the warm-up degenerates to a no-op in exactly the case that matters. Resolution mirrors `_import_master_mesh`: this tree first, then the source dirs in order, first hit wins.

## Then it exposed a second defect, and this one is nastier

With the meshes finally reaching LODGen, NehrimWorldspace listed 150,267 references and LODGen died on one of them:

```
Error processing LeyawiinHouseLower01
  System.ArgumentOutOfRangeException
  at LODGenerator.LODApp.RemoveUnseenFaces(QuadDesc, ShapeDesc) in LODApp.cs:1332
WARNING: LODGen produced no .bto tiles (exit code 548)
```

`LeyawiinLowerDoor01` in `leyawiinhouselower01_far.nif` declares `num_vertices = 16` with `has_vertices = False`: the vertex array is **not in the file**, while normals (16), vertex colours (16), UVs (16) and 6 triangles indexing up to vertex 15 all still refer to it. Oblivion tolerates that — there is nothing to draw, so it draws nothing. LODGen's face culling indexes straight into the empty list.

Measured across the shipped output: **1 of 1,552 `_far.nif`** — and that one mesh cost an entire worldspace its object LOD.

### Fix

Cleared in `_sanitize_geometry_data`, which already repairs the other class of authored geometry Oblivion tolerates and the Skyrim side does not (its NaN vertices/UVs). Cleared rather than repaired, because without positions there is nothing to repair with; the shape drew nothing before and draws nothing now.

Both geometry layouts are handled. The measured case is `NiTriStripsData`, which has **no `triangles` array at all** — a first cut cleared only `triangles`, the strips survived, the strips-to-triangles conversion downstream rebuilt them, and the shape shipped with zero vertices and six faces. That is what the second test pins.

## Result

| | before | after |
|---|---:|---:|
| worldspaces with object LOD | **0 of 18** | **17 of 18** |
| `.bto` tiles | 0 | **626** |
| NehrimWorldspace tiles | 0 | **418** |
| meshes discarded as unreadable | 2,368 | **0** |
| LODGen aborts | 1 (exit 548) | **0** |

## Verification

9 unit tests across `tests/test_lod_mesh_screening.py` and `tests/test_geometry_sanitize.py`.

The screening tests were checked against the **old** code as well, because a regression test that also passes on the broken version proves nothing. Replaying the real order — warm the cache against an empty tree, stage the mesh, screen it:

```
old code   judged safe: False   -> object dropped, LOD lost
new code   judged safe: True    -> correct
```

The tests also pin the parts that must NOT change: a real verdict is still memoised (or Tamriel's 2,582 header reads go back to being serial), and a mesh with a geometry root is still rejected — the screen must not degenerate into an existence check.

## Still open, not addressed here

`CubeWorldspace` is the one worldspace still reporting `No LOD references found`. Its meshes resolve fine ("all 5068 unique models already have `_far.nif`"); no reference passes the gates. For a 16-cell worldspace called "Cube" that is plausibly correct, but I have not proven it.

Two LOD texture warnings are unrelated to this and left alone: `default.dds`/`white.dds` are LODGen's own placeholders, and `tes4\textureslowres\...` is a single authored source path missing a separator (`textureslowres\` rather than `textures\lowres\`), which belongs with the texture-path handling rather than here.
